### PR TITLE
docs: Fix simple typo, uncluding -> including

### DIFF
--- a/dist/babelfish.js
+++ b/dist/babelfish.js
@@ -609,7 +609,7 @@ BabelFish.prototype.t = BabelFish.prototype.translate;
  *  BabelFish#stringify(locale) -> String
  *  - locale (String): Locale of translation
  *
- *  Returns serialized locale data, including fallbacks.
+ *  Returns serialized locale data, uncluding fallbacks.
  *  It can be loaded back via `load()` method.
  **/
 BabelFish.prototype.stringify = function _stringify(locale) {

--- a/dist/babelfish.js
+++ b/dist/babelfish.js
@@ -609,7 +609,7 @@ BabelFish.prototype.t = BabelFish.prototype.translate;
  *  BabelFish#stringify(locale) -> String
  *  - locale (String): Locale of translation
  *
- *  Returns serialized locale data, uncluding fallbacks.
+ *  Returns serialized locale data, including fallbacks.
  *  It can be loaded back via `load()` method.
  **/
 BabelFish.prototype.stringify = function _stringify(locale) {

--- a/lib/babelfish.js
+++ b/lib/babelfish.js
@@ -612,7 +612,7 @@ BabelFish.prototype.t = BabelFish.prototype.translate;
  *  BabelFish#stringify(locale) -> String
  *  - locale (String): Locale of translation
  *
- *  Returns serialized locale data, uncluding fallbacks.
+ *  Returns serialized locale data, including fallbacks.
  *  It can be loaded back via `load()` method.
  **/
 BabelFish.prototype.stringify = function _stringify(locale) {


### PR DESCRIPTION
There is a small typo in dist/babelfish.js, lib/babelfish.js.

Should read `including` rather than `uncluding`.

